### PR TITLE
added FAPI port to the SG

### DIFF
--- a/roles/sg_lambda/tasks/main.yml
+++ b/roles/sg_lambda/tasks/main.yml
@@ -99,7 +99,7 @@
         timeout: 90
         <<: *aws_connection_info
         environment_variables:
-          PORTS_LIST: 80,443
+          PORTS_LIST: 80,443,8444
           SECURITY_GROUP_ID: "{{ group_create.group_id }}"
       register: lambda_result
 


### PR DESCRIPTION
Adding FAPI port to the deployment of the security group. The lambda responsible for generating the security group will pick the ports and generate the security group with cloudflare ip's matching the ports 80, 443 and now 8444